### PR TITLE
Feature/hide user picks

### DIFF
--- a/controllers/AppController.php
+++ b/controllers/AppController.php
@@ -52,6 +52,7 @@ class AppController
 
     static function getUserInfo($query, $arg) {
         $db = option('db');
+        $log = option('log');
         $usr = option('empty_user');
 
         if ($result = $db->qry($query, $arg)) {
@@ -65,6 +66,8 @@ class AppController
                 $usr['reminder'] = $obj->reminder;
                 $usr['sub']      = $obj->submission;
             }
+        } else {
+            $log->log('error', 'Issue fetching user info', $db->error);
         }
 
         return $usr;

--- a/controllers/MainController.php
+++ b/controllers/MainController.php
@@ -92,6 +92,8 @@ class MainController extends AppController
                 'week_num' => $week_num,
                 'show_form' => $show_form,
                 'user_active' => $user_info['use'],
+                'user_logged_in' => $logged_user['use'],
+                'show_results' => self::show_results($challenge_active, $user_info['uid'], $logged_user['uid']),
             ));
         }
         else {
@@ -494,6 +496,22 @@ class MainController extends AppController
             die($db->error);
         }
         return $arr;
+    }
+
+    /**
+     * If the challenge is active, only show the results if the user page and active user match
+     * If the challenge is inactive, always show the results
+     */
+    static function show_results($challenge_active, $user_page, $active_user) {
+        $log = option('log');
+
+        if ($challenge_active) {
+            $log->log('info', 'User page', $user_page);
+            $log->log('info', 'Active user', $active_user);
+            return ($user_page === $active_user);
+        } else {
+            return TRUE;
+        }
     }
 }
 

--- a/views/templates/main/picks-week.html.twig
+++ b/views/templates/main/picks-week.html.twig
@@ -2,6 +2,15 @@
 
 {% block head %}
     {{ parent() }}
+    {% if not show_results %}
+        <style type="text/css">
+            #content td.picked {
+                background-color: inherit;
+                font-weight: inherit;
+            }
+        </style>
+        <script>{{ now }}</script>
+    {% endif %}
     <script type="application/javascript">
         var useTab = {{ week_num }};
     </script>

--- a/views/templates/main/picks.html.twig
+++ b/views/templates/main/picks.html.twig
@@ -2,6 +2,15 @@
 
 {% block head %}
     {{ parent() }}
+    {% if not show_results %}
+        <style type="text/css">
+            #content td.picked {
+                background-color: inherit;
+                font-weight: inherit;
+            }
+        </style>
+        <script>{{ now }}</script>
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/views/templates/main/week.html.twig
+++ b/views/templates/main/week.html.twig
@@ -15,6 +15,15 @@
         userData = {};
     {% endif %}
     </script>
+
+    {% if not show_results %}
+    <style type="text/css">
+    .user-pick {
+        background-color: inherit;
+        font-weight: inherit;
+    }
+    </style>
+    {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -44,6 +53,8 @@
                 <input id="save_btn" type="submit" value="Save"> or {{ macros.link("/", "Cancel", base_path) }}
             </p>
         </form>
+        {% elseif user_logged_in %}
+            <p>Visit {{ macros.link("/week", "your page", base_path) }} to enter your picks.</p>
         {% else %}
             <p>{{ macros.link("/login", "Login", base_path) }} to enter your picks.</p>
         {% endif %}


### PR DESCRIPTION
A user requested a feature, that while a Challenge was underway, that other users could not see what they had picked. But, once a Challenge closed, they could see all the picks of other users. The is would make sure the leader couldn't pick the same picks as the second place player to ensure they don't lose their place.
